### PR TITLE
Fix error in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ There were two different vocabularies used for the ten different test cases:
     - Major languages: Arabic, English, French, German, Italian
 
 ### Test case combinations
-For all test cases, the source is DEFC and the target is PACTOLS. There exist the following combinations of monolingual ontologies:
+For all test cases, the source is iDAI.world and the target is PACTOLS. There exist the following combinations of monolingual ontologies:
 - de-de
 - de-en
 - de-fr


### PR DESCRIPTION
DEFC instead of iDAI was mentioned as source CV

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated dataset descriptions to reflect the new source ontology "iDAI.world."
	- Revised test case combinations to include "iDAI.world."
	- Corrected typographical errors for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->